### PR TITLE
Support for newtypes using OaSchema derive macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 .cargo
+/target

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -1,18 +1,76 @@
-use syn::punctuated::Punctuated;
-use syn::token::Comma;
-use syn::Data::Struct;
-use syn::{DataStruct, DeriveInput, Field, Fields, FieldsNamed};
-
+use oasgen_core::OpenApiAttributes;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{punctuated::Punctuated, token::Comma, *};
 
 /// Given derive input of a struct, get the fields of the struct.
-pub fn get_fields(ast: &DeriveInput) -> &Punctuated<Field, Comma> {
-    let fields = match &ast.data {
-        Struct(DataStruct { ref fields, .. }) => fields,
-        _ => panic!("#[ormlite] can only be used on structs"),
+pub fn derive_oaschema_struct(ident: &Ident, fields: &Punctuated<Field, Comma>) -> TokenStream {
+    let fields: Vec<(&syn::Field, OpenApiAttributes)> = fields
+        .into_iter()
+        .map(|f| (f, OpenApiAttributes::try_from(&f.attrs).unwrap()))
+        .collect::<Vec<_>>();
+
+    let properties = fields.iter().map(|(f, attr)| {
+                    if attr.skip {
+                        return quote! {};
+                    }
+                    let name = f.ident.as_ref().unwrap().to_string();
+                    let ty = &f.ty;
+                    quote! {
+                        o.add_property(#name, <#ty as OaSchema>::schema().expect(concat!("No schema found for ", #name))).unwrap();
+                    }
+                });
+
+    let required = fields.iter().map(|(f, attr)| {
+        if attr.skip || attr.skip_serializing_if.is_some() {
+            return quote! {};
+        }
+        let name = f.ident.as_ref().unwrap().to_string();
+        quote! { #name.to_string(), }
+    });
+    let required = quote! { vec! [ #(#required)* ] };
+
+    let name = ident.to_string();
+    let ref_name = format!("#/components/schemas/{}", ident);
+    let expanded = quote! {
+        impl ::oasgen::OaSchema for #ident {
+            fn schema_name() -> Option<&'static str> {
+                Some(#name)
+            }
+
+            fn schema_ref() -> Option<::oasgen::ReferenceOr<::oasgen::Schema>> {
+                Some(::oasgen::ReferenceOr::ref_(#ref_name))
+            }
+
+            fn schema() -> Option<::oasgen::Schema> {
+                let mut o = ::oasgen::Schema::new_object();
+                #(#properties)*
+                let req = o.required_mut().unwrap();
+                *req = #required;
+                Some(o)
+            }
+        }
     };
-    let fields = match fields {
-        Fields::Named(FieldsNamed { named, .. }) => named,
-        _ => panic!("#[ormlite] can only be used on structs with named fields"),
+    TokenStream::from(expanded)
+}
+
+pub fn derive_oaschema_newtype(ident: &Ident, field: &Field) -> TokenStream {
+    let ty = &field.ty;
+    let name = ident.to_string();
+    let expanded = quote! {
+        impl ::oasgen::OaSchema for #ident {
+            fn schema_name() -> Option<&'static str> {
+                Some(<#ty as OaSchema>::schema_name().expect(concat!("No schema name found for ", #name)))
+            }
+
+            fn schema_ref() -> Option<::oasgen::ReferenceOr<::oasgen::Schema>> {
+                Some(<#ty as OaSchema>::schema_ref().expect(concat!("No schema ref found for ", #name)))
+            }
+
+            fn schema() -> Option<::oasgen::Schema> {
+                Some(<#ty as OaSchema>::schema().expect(concat!("No schema found for ", #name)))
+            }
+        }
     };
-    fields
+    TokenStream::from(expanded)
 }

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -3,7 +3,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{punctuated::Punctuated, token::Comma, *};
 
-/// Given derive input of a struct, get the fields of the struct.
+/// Create OaSchema derive token stream for a struct from ident and fields
 pub fn derive_oaschema_struct(ident: &Ident, fields: &Punctuated<Field, Comma>) -> TokenStream {
     let fields: Vec<(&syn::Field, OpenApiAttributes)> = fields
         .into_iter()
@@ -54,6 +54,7 @@ pub fn derive_oaschema_struct(ident: &Ident, fields: &Punctuated<Field, Comma>) 
     TokenStream::from(expanded)
 }
 
+/// Create OaSchema derive token stream for a newtype struct from ident and a single inner field
 pub fn derive_oaschema_newtype(ident: &Ident, field: &Field) -> TokenStream {
     let ty = &field.ty;
     let name = ident.to_string();

--- a/oasgen/tests/test-none.rs
+++ b/oasgen/tests/test-none.rs
@@ -3,4 +3,5 @@ fn run_tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/test-none/01-hello.rs");
     t.pass("tests/test-none/02-required.rs");
+    t.pass("tests/test-none/03-newtype.rs");
 }

--- a/oasgen/tests/test-none/03-newtype.rs
+++ b/oasgen/tests/test-none/03-newtype.rs
@@ -1,0 +1,29 @@
+use oasgen::OaSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct IntegerNewType(i32);
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct Struct {
+    test: i32,
+}
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct StructNewType(Struct);
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct Foo {
+    id: IntegerNewType,
+    prop_a: Struct,
+    prop_b: StructNewType,
+    #[openapi(skip)]
+    prop_c: StructNewType,
+}
+
+fn main() {
+    use pretty_assertions::assert_eq;
+    let schema = Foo::schema().unwrap();
+    let spec = serde_yaml::to_string(&schema).unwrap();
+    assert_eq!(spec.trim(), include_str!("03-newtype.yaml"));
+}

--- a/oasgen/tests/test-none/03-newtype.yaml
+++ b/oasgen/tests/test-none/03-newtype.yaml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  id:
+    type: integer
+  prop_a:
+    type: object
+    properties:
+      test:
+        type: integer
+    required:
+    - test
+  prop_b:
+    type: object
+    properties:
+      test:
+        type: integer
+    required:
+    - test
+required:
+- id
+- prop_a
+- prop_b


### PR DESCRIPTION
Allows the OaSchema derive macro to work with the newtype pattern. Following serde convention, the schema for the newtype should be identical to its inner type. This moves the derive macro closer to parity with Paperclip, which supports the newtype pattern in its derive macro.

I've implemented this because I'd like to try to switch to this crate from Paperclip because Paperclip poorly supports v3, and we use the newtype pattern all the time. Newtypes are a very useful pattern in a serialization/deserialization context because it allows the implementation of new traits on a type that serializes and deserializes identically to an inner type. This is equally useful in a schema generation context.

In the future, I'd also like to add support to the OaSchema macro for enums, so the pattern matching used in `pub fn derive_oaschema` was written to be easily extendable, and the body of the separate matches were moved into their own functions for readability with the intent that more may be added.

An alternative option would be to create a whole new macro specifically for newtypes. But I figure that modifying OaSchema is better because supporting newtypes is unambiguous and allows strictly a superset of types that may be derived, and the behavior follows serde convention.

Of course if there are any changes for this MR to be accepted feel free to reach out. If derive newtype was left out by design, I would be content creating another crate with a macro for deriving it.