### PR TITLE
Support for simple enums using OaSchema derive macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 .cargo
+/target

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -2,8 +2,8 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data::Struct, *};
-use util::{derive_oaschema_newtype, derive_oaschema_struct};
+use syn::{Data, *};
+use util::{derive_oaschema_enum, derive_oaschema_newtype, derive_oaschema_struct};
 
 mod util;
 
@@ -13,14 +13,15 @@ pub fn derive_oaschema(item: TokenStream) -> TokenStream {
     let id = &ast.ident;
 
     match &ast.data {
-        Struct(DataStruct { ref fields, .. }) => match fields {
+        Data::Struct(DataStruct { ref fields, .. }) => match fields {
             Fields::Named(FieldsNamed { named: fields, .. }) => derive_oaschema_struct(id, fields),
             Fields::Unnamed(FieldsUnnamed { unnamed, .. }) if unnamed.len() == 1 => {
                 derive_oaschema_newtype(id, unnamed.first().unwrap())
             }
             _ => panic!("#[ormlite] can only be used on structs with named fields or newtypes"),
         },
-        _ => panic!("#[ormlite] can only be used on structs"),
+        Data::Enum(DataEnum { variants, .. }) => derive_oaschema_enum(id, variants),
+        Data::Union(_) => panic!("#[ormlite] can not be used on unions"),
     }
 }
 

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -76,7 +76,7 @@ pub fn derive_oaschema_newtype(ident: &Ident, field: &Field) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-/// Create OaSchema derive token stream for a struct from ident and fields
+/// Create OaSchema derive token stream for an enum from ident and variants
 pub fn derive_oaschema_enum(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> TokenStream {
     let variants: Vec<(&syn::Variant, OpenApiAttributes)> = variants
         .into_iter()

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -1,18 +1,76 @@
-use syn::punctuated::Punctuated;
-use syn::token::Comma;
-use syn::Data::Struct;
-use syn::{DataStruct, DeriveInput, Field, Fields, FieldsNamed};
-
+use oasgen_core::OpenApiAttributes;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{punctuated::Punctuated, token::Comma, *};
 
 /// Given derive input of a struct, get the fields of the struct.
-pub fn get_fields(ast: &DeriveInput) -> &Punctuated<Field, Comma> {
-    let fields = match &ast.data {
-        Struct(DataStruct { ref fields, .. }) => fields,
-        _ => panic!("#[ormlite] can only be used on structs"),
+pub fn derive_oaschema_struct(ident: &Ident, fields: &Punctuated<Field, Comma>) -> TokenStream {
+    let fields: Vec<(&syn::Field, OpenApiAttributes)> = fields
+        .into_iter()
+        .map(|f| (f, OpenApiAttributes::try_from(&f.attrs).unwrap()))
+        .collect::<Vec<_>>();
+
+    let properties = fields.iter().map(|(f, attr)| {
+                    if attr.skip {
+                        return quote! {};
+                    }
+                    let name = f.ident.as_ref().unwrap().to_string();
+                    let ty = &f.ty;
+                    quote! {
+                        o.add_property(#name, <#ty as OaSchema>::schema().expect(concat!("No schema found for ", #name))).unwrap();
+                    }
+                });
+
+    let required = fields.iter().map(|(f, attr)| {
+        if attr.skip || attr.skip_serializing_if.is_some() {
+            return quote! {};
+        }
+        let name = f.ident.as_ref().unwrap().to_string();
+        quote! { #name.to_string(), }
+    });
+    let required = quote! { vec! [ #(#required)* ] };
+
+    let name = ident.to_string();
+    let ref_name = format!("#/components/schemas/{}", ident);
+    let expanded = quote! {
+        impl ::oasgen::OaSchema for #ident {
+            fn schema_name() -> Option<&'static str> {
+                Some(#name)
+            }
+
+            fn schema_ref() -> Option<::oasgen::ReferenceOr<::oasgen::Schema>> {
+                Some(::oasgen::ReferenceOr::ref_(#ref_name))
+            }
+
+            fn schema() -> Option<::oasgen::Schema> {
+                let mut o = ::oasgen::Schema::new_object();
+                #(#properties)*
+                let req = o.required_mut().unwrap();
+                *req = #required;
+                Some(o)
+            }
+        }
     };
-    let fields = match fields {
-        Fields::Named(FieldsNamed { named, .. }) => named,
-        _ => panic!("#[ormlite] can only be used on structs with named fields"),
+    TokenStream::from(expanded)
+}
+
+pub fn derive_oaschema_newtype(ident: &Ident, field: &Field) -> TokenStream {
+    let ty = &field.ty;
+    let name = ident.to_string();
+    let expanded = quote! {
+        impl ::oasgen::OaSchema for #ident {
+            fn schema_name() -> Option<&'static str> {
+                Some(<#ty as OaSchema>::schema_name().expect(concat!("No schema name found for ", #name)))
+            }
+
+            fn schema_ref() -> Option<::oasgen::ReferenceOr<::oasgen::Schema>> {
+                Some(<#ty as OaSchema>::schema_ref().expect(concat!("No schema ref found for ", #name)))
+            }
+
+            fn schema() -> Option<::oasgen::Schema> {
+                Some(<#ty as OaSchema>::schema().expect(concat!("No schema found for ", #name)))
+            }
+        }
     };
-    fields
+    TokenStream::from(expanded)
 }

--- a/oasgen/tests/test-none.rs
+++ b/oasgen/tests/test-none.rs
@@ -4,4 +4,5 @@ fn run_tests() {
     t.pass("tests/test-none/01-hello.rs");
     t.pass("tests/test-none/02-required.rs");
     t.pass("tests/test-none/03-newtype.rs");
+    t.pass("tests/test-none/04-enum.rs");
 }

--- a/oasgen/tests/test-none.rs
+++ b/oasgen/tests/test-none.rs
@@ -3,4 +3,5 @@ fn run_tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/test-none/01-hello.rs");
     t.pass("tests/test-none/02-required.rs");
+    t.pass("tests/test-none/03-newtype.rs");
 }

--- a/oasgen/tests/test-none/03-newtype.rs
+++ b/oasgen/tests/test-none/03-newtype.rs
@@ -1,0 +1,29 @@
+use oasgen::OaSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct IntegerNewType(i32);
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct Struct {
+    test: i32,
+}
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct StructNewType(Struct);
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct Foo {
+    id: IntegerNewType,
+    prop_a: Struct,
+    prop_b: StructNewType,
+    #[openapi(skip)]
+    prop_c: StructNewType,
+}
+
+fn main() {
+    use pretty_assertions::assert_eq;
+    let schema = Foo::schema().unwrap();
+    let spec = serde_yaml::to_string(&schema).unwrap();
+    assert_eq!(spec.trim(), include_str!("03-newtype.yaml"));
+}

--- a/oasgen/tests/test-none/03-newtype.yaml
+++ b/oasgen/tests/test-none/03-newtype.yaml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  id:
+    type: integer
+  prop_a:
+    type: object
+    properties:
+      test:
+        type: integer
+    required:
+    - test
+  prop_b:
+    type: object
+    properties:
+      test:
+        type: integer
+    required:
+    - test
+required:
+- id
+- prop_a
+- prop_b

--- a/oasgen/tests/test-none/04-enum.rs
+++ b/oasgen/tests/test-none/04-enum.rs
@@ -1,0 +1,22 @@
+use oasgen::OaSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub enum Duration {
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct Foo {
+    duration: Duration,
+}
+
+fn main() {
+    use pretty_assertions::assert_eq;
+    let schema = Foo::schema().unwrap();
+    let spec = serde_yaml::to_string(&schema).unwrap();
+    assert_eq!(spec.trim(), include_str!("04-enum.yaml"));
+}

--- a/oasgen/tests/test-none/04-enum.rs
+++ b/oasgen/tests/test-none/04-enum.rs
@@ -6,6 +6,7 @@ pub enum Duration {
     Day,
     Week,
     Month,
+    #[openapi(skip)]
     Year,
 }
 

--- a/oasgen/tests/test-none/04-enum.yaml
+++ b/oasgen/tests/test-none/04-enum.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  duration:
+    type: string
+    enum:
+    - day
+    - week
+    - month
+    - year
+required:
+- duration

--- a/oasgen/tests/test-none/04-enum.yaml
+++ b/oasgen/tests/test-none/04-enum.yaml
@@ -6,6 +6,5 @@ properties:
     - Day
     - Week
     - Month
-    - Year
 required:
 - duration

--- a/oasgen/tests/test-none/04-enum.yaml
+++ b/oasgen/tests/test-none/04-enum.yaml
@@ -3,9 +3,9 @@ properties:
   duration:
     type: string
     enum:
-    - day
-    - week
-    - month
-    - year
+    - Day
+    - Week
+    - Month
+    - Year
 required:
 - duration


### PR DESCRIPTION
Allows the OaSchema derive macro to work with simple str enums. These are enums whose variants contain no fields. This generates an openapi v3 string which uses the enum keyword to denote the possible literal variants, for example:

```
type: string
enum:
- Day
- Week
- Month
```

In the future, it should be possible to detect non-simple enums and implement them using the `oneOf` keyword.

This PR depends on PR #2 