### PR TITLE
Impl oaschema hashmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 .cargo
+/target

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -1,5 +1,8 @@
+use std::collections::HashMap;
+
+use oa::AdditionalProperties;
 use openapiv3 as oa;
-use openapiv3::{Schema, SchemaKind, SchemaData, ArrayType, Type, ReferenceOr};
+use openapiv3::{ArrayType, ObjectType, ReferenceOr, Schema, SchemaData, SchemaKind, Type};
 
 #[cfg(feature = "actix")]
 mod actix;
@@ -7,16 +10,16 @@ mod actix;
 #[cfg(feature = "axum")]
 mod axum;
 
-#[cfg(feature = "sqlx")]
-mod sqlx;
-#[cfg(feature = "time")]
-mod time;
 #[cfg(feature = "chrono")]
 mod chrono;
 #[cfg(feature = "cookies")]
 mod cookies;
 #[cfg(feature = "phonenumber")]
 mod phonenumber;
+#[cfg(feature = "sqlx")]
+mod sqlx;
+#[cfg(feature = "time")]
+mod time;
 
 mod http;
 #[cfg(feature = "sid")]
@@ -58,7 +61,10 @@ macro_rules! impl_oa_schema {
 #[macro_export]
 macro_rules! impl_oa_schema_passthrough {
     ($t:ty) => {
-        impl<T> $crate::OaSchema for $t where T: $crate::OaSchema {
+        impl<T> $crate::OaSchema for $t
+        where
+            T: $crate::OaSchema,
+        {
             fn schema_name() -> Option<&'static str> {
                 T::schema_name()
             }
@@ -77,8 +83,7 @@ macro_rules! impl_oa_schema_passthrough {
 #[macro_export]
 macro_rules! impl_oa_schema_none {
     ($t:ty) => {
-        impl $crate::OaSchema for $t {
-        }
+        impl $crate::OaSchema for $t {}
     };
 }
 
@@ -99,8 +104,8 @@ impl_oa_schema!(f64, Schema::new_number());
 impl_oa_schema!(String, Schema::new_string());
 
 impl<T> OaSchema for Vec<T>
-    where
-        T: OaSchema,
+where
+    T: OaSchema,
 {
     fn schema_ref() -> Option<ReferenceOr<Schema>> {
         Some(ReferenceOr::Item(Schema {
@@ -127,10 +132,9 @@ impl<T> OaSchema for Vec<T>
     }
 }
 
-
 impl<T> OaSchema for Option<T>
-    where
-        T: OaSchema,
+where
+    T: OaSchema,
 {
     fn schema_name() -> Option<&'static str> {
         T::schema_name()
@@ -149,8 +153,8 @@ impl<T> OaSchema for Option<T>
 }
 
 impl<T, E> OaSchema for Result<T, E>
-    where
-        T: OaSchema,
+where
+    T: OaSchema,
 {
     fn schema_name() -> Option<&'static str> {
         T::schema_name()
@@ -162,6 +166,34 @@ impl<T, E> OaSchema for Result<T, E>
 
     fn schema() -> Option<Schema> {
         T::schema()
+    }
+}
+
+impl<K, V> OaSchema for HashMap<K, V>
+where
+    V: OaSchema,
+{
+    fn schema_ref() -> Option<ReferenceOr<Schema>> {
+        Some(ReferenceOr::Item(Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::Object(ObjectType {
+                additional_properties: Some(AdditionalProperties::Schema(Box::new(
+                    V::schema_ref()?
+                ))),
+                ..ObjectType::default()
+            })),
+        }))
+    }
+
+    fn schema() -> Option<Schema> {
+        Some(Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::Object(ObjectType {
+                additional_properties: V::schema()
+                    .map(|s| AdditionalProperties::Schema(Box::new(ReferenceOr::Item(s)))),
+                ..ObjectType::default()
+            })),
+        })
     }
 }
 

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -20,6 +20,7 @@ quote = "1.0"
 proc-macro2 = "1.0.64"
 oasgen-core = { path = "../core" , version = "0.13.0"}
 structmeta = "0.2.0"
+serde_derive_internals = "0.28.0"
 
 [dev-dependencies]
 trybuild = "1.0.81"

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -2,8 +2,8 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data::Struct, *};
-use util::{derive_oaschema_newtype, derive_oaschema_struct};
+use syn::{Data, *};
+use util::{derive_oaschema_enum, derive_oaschema_newtype, derive_oaschema_struct};
 
 mod util;
 
@@ -13,14 +13,15 @@ pub fn derive_oaschema(item: TokenStream) -> TokenStream {
     let id = &ast.ident;
 
     match &ast.data {
-        Struct(DataStruct { ref fields, .. }) => match fields {
+        Data::Struct(DataStruct { ref fields, .. }) => match fields {
             Fields::Named(FieldsNamed { named: fields, .. }) => derive_oaschema_struct(id, fields),
             Fields::Unnamed(FieldsUnnamed { unnamed, .. }) if unnamed.len() == 1 => {
                 derive_oaschema_newtype(id, unnamed.first().unwrap())
             }
             _ => panic!("#[ormlite] can only be used on structs with named fields or newtypes"),
         },
-        _ => panic!("#[ormlite] can only be used on structs"),
+        Data::Enum(DataEnum { variants, .. }) => derive_oaschema_enum(id, variants),
+        Data::Union(_) => panic!("#[ormlite] can not be used on unions"),
     }
 }
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -17,7 +17,7 @@ pub fn derive_oaschema(item: TokenStream) -> TokenStream {
 
     let cont = {
         let ctxt = Ctxt::new();
-        let cont = Container::from_ast(&ctxt, &ast, Derive::Serialize);
+        let cont = Container::from_ast(&ctxt, &ast, Derive::Deserialize);
         ctxt.check().unwrap();
         cont.unwrap()
     };

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -2,7 +2,11 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data, *};
+use serde_derive_internals::{
+    ast::{Container, Data, Style},
+    Ctxt, Derive,
+};
+use syn::*;
 use util::{derive_oaschema_enum, derive_oaschema_newtype, derive_oaschema_struct};
 
 mod util;
@@ -10,18 +14,25 @@ mod util;
 #[proc_macro_derive(OaSchema, attributes(openapi))]
 pub fn derive_oaschema(item: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(item as DeriveInput);
-    let id = &ast.ident;
 
-    match &ast.data {
-        Data::Struct(DataStruct { ref fields, .. }) => match fields {
-            Fields::Named(FieldsNamed { named: fields, .. }) => derive_oaschema_struct(id, fields),
-            Fields::Unnamed(FieldsUnnamed { unnamed, .. }) if unnamed.len() == 1 => {
-                derive_oaschema_newtype(id, unnamed.first().unwrap())
-            }
-            _ => panic!("#[ormlite] can only be used on structs with named fields or newtypes"),
-        },
-        Data::Enum(DataEnum { variants, .. }) => derive_oaschema_enum(id, variants),
-        Data::Union(_) => panic!("#[ormlite] can not be used on unions"),
+    let cont = {
+        let ctxt = Ctxt::new();
+        let cont = Container::from_ast(&ctxt, &ast, Derive::Serialize);
+        ctxt.check().unwrap();
+        cont.unwrap()
+    };
+
+    let id = &cont.ident;
+
+    match &cont.data {
+        Data::Struct(Style::Struct, fields) => derive_oaschema_struct(id, fields),
+        Data::Struct(Style::Newtype, fields) => {
+            derive_oaschema_newtype(id, fields.first().unwrap())
+        }
+        Data::Struct(_, _) => {
+            panic!("#[ormlite] can only be used on structs with named fields or newtypes")
+        }
+        Data::Enum(variants) => derive_oaschema_enum(id, variants),
     }
 }
 

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -23,12 +23,12 @@ pub fn derive_oaschema_struct(ident: &Ident, fields: &[Field]) -> TokenStream {
 
             if f.attrs.flatten() {
                 quote! {
-                    if let oasgen_core::SchemaKind::Type(oasgen_core::Type::Object(oasgen_core::ObjectType { properties, required, .. }))
+                    if let ::oasgen::SchemaKind::Type(::oasgen::Type::Object(::oasgen::ObjectType { properties, required, .. }))
                             = #schema.schema_kind {
                         for (name, schema) in properties.into_iter() {
                             match schema {
-                                oasgen_core::ReferenceOr::Item(mut item) => o.add_property(&name, item.clone()).unwrap(),
-                                oasgen_core::ReferenceOr::Reference {..} => panic!("Cannot flatten a reference")
+                                ::oasgen::ReferenceOr::Item(mut item) => o.add_property(&name, item.clone()).unwrap(),
+                                ::oasgen::ReferenceOr::Reference {..} => panic!("Cannot flatten a reference")
                             }
                         }
                         o.required_mut().unwrap().extend_from_slice(&required);

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -76,7 +76,7 @@ pub fn derive_oaschema_newtype(ident: &Ident, field: &Field) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-/// Create OaSchema derive token stream for a struct from ident and fields
+/// Create OaSchema derive token stream for an enum from ident and variants
 pub fn derive_oaschema_enum(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> TokenStream {
     let variants: Vec<(&syn::Variant, OpenApiAttributes)> = variants
         .into_iter()

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -1,18 +1,76 @@
-use syn::punctuated::Punctuated;
-use syn::token::Comma;
-use syn::Data::Struct;
-use syn::{DataStruct, DeriveInput, Field, Fields, FieldsNamed};
-
+use oasgen_core::OpenApiAttributes;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{punctuated::Punctuated, token::Comma, *};
 
 /// Given derive input of a struct, get the fields of the struct.
-pub fn get_fields(ast: &DeriveInput) -> &Punctuated<Field, Comma> {
-    let fields = match &ast.data {
-        Struct(DataStruct { ref fields, .. }) => fields,
-        _ => panic!("#[ormlite] can only be used on structs"),
+pub fn derive_oaschema_struct(ident: &Ident, fields: &Punctuated<Field, Comma>) -> TokenStream {
+    let fields: Vec<(&syn::Field, OpenApiAttributes)> = fields
+        .into_iter()
+        .map(|f| (f, OpenApiAttributes::try_from(&f.attrs).unwrap()))
+        .collect::<Vec<_>>();
+
+    let properties = fields.iter().map(|(f, attr)| {
+                    if attr.skip {
+                        return quote! {};
+                    }
+                    let name = f.ident.as_ref().unwrap().to_string();
+                    let ty = &f.ty;
+                    quote! {
+                        o.add_property(#name, <#ty as OaSchema>::schema().expect(concat!("No schema found for ", #name))).unwrap();
+                    }
+                });
+
+    let required = fields.iter().map(|(f, attr)| {
+        if attr.skip || attr.skip_serializing_if.is_some() {
+            return quote! {};
+        }
+        let name = f.ident.as_ref().unwrap().to_string();
+        quote! { #name.to_string(), }
+    });
+    let required = quote! { vec! [ #(#required)* ] };
+
+    let name = ident.to_string();
+    let ref_name = format!("#/components/schemas/{}", ident);
+    let expanded = quote! {
+        impl ::oasgen::OaSchema for #ident {
+            fn schema_name() -> Option<&'static str> {
+                Some(#name)
+            }
+
+            fn schema_ref() -> Option<::oasgen::ReferenceOr<::oasgen::Schema>> {
+                Some(::oasgen::ReferenceOr::ref_(#ref_name))
+            }
+
+            fn schema() -> Option<::oasgen::Schema> {
+                let mut o = ::oasgen::Schema::new_object();
+                #(#properties)*
+                let req = o.required_mut().unwrap();
+                *req = #required;
+                Some(o)
+            }
+        }
     };
-    let fields = match fields {
-        Fields::Named(FieldsNamed { named, .. }) => named,
-        _ => panic!("#[ormlite] can only be used on structs with named fields"),
+    TokenStream::from(expanded)
+}
+
+pub fn derive_oaschema_newtype(ident: &Ident, field: &Field) -> TokenStream {
+    let ty = &field.ty;
+    let name = ident.to_string();
+    let expanded = quote! {
+        impl ::oasgen::OaSchema for #ident {
+            fn schema_name() -> Option<&'static str> {
+                Some(<#ty as OaSchema>::schema_name().expect(concat!("No schema name found for ", #name)))
+            }
+
+            fn schema_ref() -> Option<::oasgen::ReferenceOr<::oasgen::Schema>> {
+                Some(<#ty as OaSchema>::schema_ref().expect(concat!("No schema ref found for ", #name)))
+            }
+
+            fn schema() -> Option<::oasgen::Schema> {
+                Some(<#ty as OaSchema>::schema().expect(concat!("No schema found for ", #name)))
+            }
+        }
     };
-    fields
+    TokenStream::from(expanded)
 }

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -95,19 +95,19 @@ pub fn derive_oaschema_newtype(ident: &Ident, field: &Field) -> TokenStream {
 
 /// Create OaSchema derive token stream for an enum from ident and variants
 pub fn derive_oaschema_enum(ident: &Ident, variants: &[Variant]) -> TokenStream {
-    let variants: Vec<(&Variant, OpenApiAttributes)> = variants
+    let str_variants = variants
         .into_iter()
-        .map(|v| (v, OpenApiAttributes::try_from(&v.original.attrs).unwrap()))
-        .collect::<Vec<_>>();
+        .map(|v| {
+            let openapi_attrs = OpenApiAttributes::try_from(&v.original.attrs).unwrap();
 
-    let str_variants = variants.iter().map(|(v, attr)| {
-        if attr.skip {
-            return quote! {};
-        }
-        assert!(v.fields.len() == 0, "Enum with fields not supported.");
-        let name = v.attrs.name().deserialize_name();
-        quote! { #name.to_string(), }
-    });
+            if openapi_attrs.skip {
+                return quote! {};
+            }
+            assert!(v.fields.len() == 0, "Enum with fields not supported.");
+            let name = v.attrs.name().deserialize_name();
+            quote! { #name.to_string(), }
+        })
+        .collect::<Vec<_>>();
 
     let name = ident.to_string();
     let ref_name = format!("#/components/schemas/{}", ident);

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -15,7 +15,7 @@ pub fn derive_oaschema_struct(ident: &Ident, fields: &[Field]) -> TokenStream {
                 return quote! {};
             }
 
-            let name = f.attrs.name().serialize_name();
+            let name = f.attrs.name().deserialize_name();
             let ty = f.ty;
 
             if f.attrs.flatten() {
@@ -102,7 +102,7 @@ pub fn derive_oaschema_enum(ident: &Ident, variants: &[Variant]) -> TokenStream 
             return quote! {};
         }
         assert!(v.fields.len() == 0, "Enum with fields not supported.");
-        let name = v.ident.to_string();
+        let name = v.attrs.name().deserialize_name();
         quote! { #name.to_string(), }
     });
 

--- a/oasgen/tests/test-none.rs
+++ b/oasgen/tests/test-none.rs
@@ -4,4 +4,5 @@ fn run_tests() {
     t.pass("tests/test-none/01-hello.rs");
     t.pass("tests/test-none/02-required.rs");
     t.pass("tests/test-none/03-newtype.rs");
+    t.pass("tests/test-none/04-enum.rs");
 }

--- a/oasgen/tests/test-none.rs
+++ b/oasgen/tests/test-none.rs
@@ -3,4 +3,5 @@ fn run_tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/test-none/01-hello.rs");
     t.pass("tests/test-none/02-required.rs");
+    t.pass("tests/test-none/03-newtype.rs");
 }

--- a/oasgen/tests/test-none.rs
+++ b/oasgen/tests/test-none.rs
@@ -5,4 +5,5 @@ fn run_tests() {
     t.pass("tests/test-none/02-required.rs");
     t.pass("tests/test-none/03-newtype.rs");
     t.pass("tests/test-none/04-enum.rs");
+    t.pass("tests/test-none/05-serde-attrs.rs");
 }

--- a/oasgen/tests/test-none/03-newtype.rs
+++ b/oasgen/tests/test-none/03-newtype.rs
@@ -1,0 +1,29 @@
+use oasgen::OaSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct IntegerNewType(i32);
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct Struct {
+    test: i32,
+}
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct StructNewType(Struct);
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct Foo {
+    id: IntegerNewType,
+    prop_a: Struct,
+    prop_b: StructNewType,
+    #[openapi(skip)]
+    prop_c: StructNewType,
+}
+
+fn main() {
+    use pretty_assertions::assert_eq;
+    let schema = Foo::schema().unwrap();
+    let spec = serde_yaml::to_string(&schema).unwrap();
+    assert_eq!(spec.trim(), include_str!("03-newtype.yaml"));
+}

--- a/oasgen/tests/test-none/03-newtype.yaml
+++ b/oasgen/tests/test-none/03-newtype.yaml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  id:
+    type: integer
+  prop_a:
+    type: object
+    properties:
+      test:
+        type: integer
+    required:
+    - test
+  prop_b:
+    type: object
+    properties:
+      test:
+        type: integer
+    required:
+    - test
+required:
+- id
+- prop_a
+- prop_b

--- a/oasgen/tests/test-none/04-enum.rs
+++ b/oasgen/tests/test-none/04-enum.rs
@@ -1,0 +1,22 @@
+use oasgen::OaSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub enum Duration {
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+#[derive(OaSchema, Serialize, Deserialize)]
+pub struct Foo {
+    duration: Duration,
+}
+
+fn main() {
+    use pretty_assertions::assert_eq;
+    let schema = Foo::schema().unwrap();
+    let spec = serde_yaml::to_string(&schema).unwrap();
+    assert_eq!(spec.trim(), include_str!("04-enum.yaml"));
+}

--- a/oasgen/tests/test-none/04-enum.rs
+++ b/oasgen/tests/test-none/04-enum.rs
@@ -6,6 +6,7 @@ pub enum Duration {
     Day,
     Week,
     Month,
+    #[openapi(skip)]
     Year,
 }
 

--- a/oasgen/tests/test-none/04-enum.yaml
+++ b/oasgen/tests/test-none/04-enum.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  duration:
+    type: string
+    enum:
+    - day
+    - week
+    - month
+    - year
+required:
+- duration

--- a/oasgen/tests/test-none/04-enum.yaml
+++ b/oasgen/tests/test-none/04-enum.yaml
@@ -6,6 +6,5 @@ properties:
     - Day
     - Week
     - Month
-    - Year
 required:
 - duration

--- a/oasgen/tests/test-none/04-enum.yaml
+++ b/oasgen/tests/test-none/04-enum.yaml
@@ -3,9 +3,9 @@ properties:
   duration:
     type: string
     enum:
-    - day
-    - week
-    - month
-    - year
+    - Day
+    - Week
+    - Month
+    - Year
 required:
 - duration

--- a/oasgen/tests/test-none/05-serde-attrs.rs
+++ b/oasgen/tests/test-none/05-serde-attrs.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(OaSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Bar {
+    #[serde(rename = "is_renamed")]
     is_required: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     is_not_required: Option<String>,
@@ -11,10 +12,22 @@ pub struct Bar {
 
 #[derive(OaSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub enum Duration {
+    Day,
+    #[serde(rename = "renamedWeek")]
+    Week,
+    Month,
+    #[openapi(skip)]
+    Year,
+}
+
+#[derive(OaSchema, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Foo {
-    prop_a: Bar,
+    camel_bar: Bar,
+    camel_duration: Duration,
     #[serde(flatten)]
-    prop_b: Bar,
+    flattened: Bar,
 }
 
 fn main() {

--- a/oasgen/tests/test-none/05-serde-attrs.rs
+++ b/oasgen/tests/test-none/05-serde-attrs.rs
@@ -1,0 +1,25 @@
+use oasgen::OaSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(OaSchema, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Bar {
+    is_required: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    is_not_required: Option<String>,
+}
+
+#[derive(OaSchema, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Foo {
+    prop_a: Bar,
+    #[serde(flatten)]
+    prop_b: Bar,
+}
+
+fn main() {
+    use pretty_assertions::assert_eq;
+    let schema = Foo::schema().unwrap();
+    let spec = serde_yaml::to_string(&schema).unwrap();
+    assert_eq!(spec.trim(), include_str!("05-serde-attrs.yaml"));
+}

--- a/oasgen/tests/test-none/05-serde-attrs.yaml
+++ b/oasgen/tests/test-none/05-serde-attrs.yaml
@@ -1,20 +1,27 @@
 type: object
 properties:
-  propA:
+  camelBar:
     type: object
     properties:
-      isRequired:
+      is_renamed:
         type: integer
       isNotRequired:
         nullable: true
         type: string
     required:
-    - isRequired
-  isRequired:
+    - is_renamed
+  camelDuration:
+    type: string
+    enum:
+    - day
+    - renamedWeek
+    - month
+  is_renamed:
     type: integer
   isNotRequired:
     nullable: true
     type: string
 required:
-- propA
-- isRequired
+- camelBar
+- camelDuration
+- is_renamed

--- a/oasgen/tests/test-none/05-serde-attrs.yaml
+++ b/oasgen/tests/test-none/05-serde-attrs.yaml
@@ -1,0 +1,20 @@
+type: object
+properties:
+  propA:
+    type: object
+    properties:
+      isRequired:
+        type: integer
+      isNotRequired:
+        nullable: true
+        type: string
+    required:
+    - isRequired
+  isRequired:
+    type: integer
+  isNotRequired:
+    nullable: true
+    type: string
+required:
+- propA
+- isRequired


### PR DESCRIPTION
Implements OaSchema on HashMap to represent openapi v3 dictionaries. Openapi v3 dictionaries only support string keys. serde_json will error if the key cannot serialize into a string, but the error is given at runtime and I am unsure what appropriate compile time bound to use to enforce this, so I have left the key unbounded. We probably also want to support BTreeMap, but we could add that to a separate PR.