### PR TITLE
Reduce library size by replacing regex with regex-lite

### DIFF
--- a/oasgen/Cargo.toml
+++ b/oasgen/Cargo.toml
@@ -53,7 +53,7 @@ serde_yaml = "0.9.22"
 tokio = { version = "1.29.1", features = ["full"] }
 swagger-ui2 = { version = "0.6", optional = true, path = "../swagger-ui" }
 tower-cookies = { version = "0.10.0", optional = true }
-regex = "1.9.1"
+regex-lite = "0.1.5"
 once_cell = "1.18.0"
 http-body = "1.0.0"
 http-body-util = "0.1.0"

--- a/oasgen/src/server.rs
+++ b/oasgen/src/server.rs
@@ -238,7 +238,7 @@ fn replace_path_params(path: &str) -> String {
         return path.to_string();
     }
     use once_cell::sync::OnceCell;
-    use regex::Regex;
+    use regex_lite::Regex;
     static REMAP: OnceCell<Regex> = OnceCell::new();
     let remap = REMAP.get_or_init(|| Regex::new("/:([a-zA-Z0-9_]+)").unwrap());
     remap.replace_all(&path, "/{$1}").to_string()


### PR DESCRIPTION
For the use case regex-light should be sufficient
It reduces the binary size by about 1MB

I first thought about putting regex-lite behind a feature, but looking at the use cases I think we can just completely switch to regex-lite.