### PR TITLE
Actix features/refactor

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -17,7 +17,7 @@ check:
 alias c := check
 
 fix:
-    cargo clippy --fix
+    cargo clippy --all-features --all-targets --fix
 
 # Bump version. level=major,minor,patch
 version level:

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -96,6 +96,7 @@ impl_oa_schema!(f32, Schema::new_number());
 impl_oa_schema!(f64, Schema::new_number());
 
 impl_oa_schema!(String, Schema::new_string());
+impl_oa_schema!(&str, Schema::new_string());
 
 impl<T> OaSchema for Vec<T>
 where

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -113,6 +113,21 @@ where
     }
 }
 
+impl<T, const N: usize> OaSchema for [T; N]
+where
+    T: OaSchema,
+{
+    fn schema() -> Schema {
+        let inner = T::schema();
+        Schema::new_array(inner)
+    }
+
+    fn schema_ref() -> ReferenceOr<Schema> {
+        let inner = T::schema_ref();
+        ReferenceOr::Item(Schema::new_array(inner))
+    }
+}
+
 impl<T> OaSchema for Option<T>
 where
     T: OaSchema,

--- a/core/src/schema/actix.rs
+++ b/core/src/schema/actix.rs
@@ -18,12 +18,23 @@ impl OaSchema for actix_web::HttpResponse {
 impl<T> OaParameter for actix_web::web::Data<T> {}
 impl OaParameter for actix_web::HttpRequest {}
 
-
 impl<T: OaParameter> OaParameter for actix_web::web::Path<T> {
     fn parameters() -> Vec<RefOr<oa::Parameter>> {
         T::parameter_schemas()
             .into_iter()
-            .map(|s| RefOr::Item(oa::Parameter::path("path", s)))
+            .flat_map(|s| s.into_item())
+            .enumerate()
+            .flat_map(|(i, s)| -> Box<dyn Iterator<Item = _>> {
+                match s.kind {
+                    SchemaKind::Type(Type::Object(o)) => Box::new(o.properties.into_iter()),
+                    _ => Box::new(Some((format!("path{i}"), RefOr::Item(s))).into_iter()),
+                }
+            })
+            .map(|(k, v)| {
+                let mut param = oa::Parameter::path(k, v);
+                param.required = true;
+                RefOr::Item(param)
+            })
             .collect()
     }
 }
@@ -34,8 +45,8 @@ impl<T: OaParameter> OaParameter for actix_web::web::Query<T> {
             .into_iter()
             .flat_map(|s| s.into_item())
             .flat_map(|s| match s.kind {
-                SchemaKind::Type(Type::Object(o)) => { Some(o.properties) }
-                _ => None
+                SchemaKind::Type(Type::Object(o)) => Some(o.properties),
+                _ => None,
             })
             .flatten()
             .map(|(k, v)| RefOr::Item(oa::Parameter::query(k, v)))
@@ -46,9 +57,6 @@ impl<T: OaParameter> OaParameter for actix_web::web::Query<T> {
 #[cfg(feature = "qs")]
 impl<T: OaParameter> OaParameter for serde_qs::actix::QsQuery<T> {
     fn parameters() -> Vec<RefOr<oa::Parameter>> {
-        T::parameter_schemas()
-            .into_iter()
-            .map(|s| RefOr::Item(oa::Parameter::query("query", s)))
-            .collect()
+        actix_web::web::Query::<T>::parameters()
     }
 }

--- a/macro/src/attr.rs
+++ b/macro/src/attr.rs
@@ -14,6 +14,7 @@ pub struct FieldAttributes {
     /// By default, oasgen will use references when possible
     /// If you want to inline the schema, use `#[oasgen(inline)]`
     pub inline: bool,
+    pub rename: Option<LitStr>,
 }
 
 impl FieldAttributes {

--- a/macro/src/attr.rs
+++ b/macro/src/attr.rs
@@ -47,7 +47,7 @@ impl TryFrom<&Vec<syn::Attribute>> for FieldAttributes {
 
     fn try_from(attrs: &Vec<syn::Attribute>) -> Result<Self, Self::Error> {
         let attrs = attrs
-            .into_iter()
+            .iter()
             .filter(|a| a.path().get_ident().map(|i| i == "oasgen").unwrap_or(false))
             .map(|a| a.parse_args())
             .collect::<Result<Vec<FieldAttributes>, syn::Error>>()?;

--- a/macro/src/attr.rs
+++ b/macro/src/attr.rs
@@ -2,7 +2,7 @@ use quote::ToTokens;
 use serde_derive_internals::ast::Field;
 use structmeta::StructMeta;
 use syn::spanned::Spanned;
-use syn::LitStr;
+use syn::{Ident, LitStr};
 
 /// Available attributes on a struct
 /// For attributes that have the same name as `serde` attributes, you can use either one.
@@ -68,6 +68,8 @@ pub struct OperationAttributes {
     pub tags: Option<Vec<LitStr>>,
     pub operation_id: Option<LitStr>,
     pub deprecated: bool,
+    pub skip: Option<Vec<Ident>>,
+    pub skip_all: bool,
 }
 
 impl OperationAttributes {

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -124,7 +124,7 @@ pub fn derive_oaschema_enum(
     tag: &TagType,
     _docstring: Option<String>,
 ) -> TokenStream {
-    let variants = variants.into_iter().filter(|v| {
+    let variants = variants.iter().filter(|v| {
         let openapi_attrs = FieldAttributes::try_from(&v.original.attrs).unwrap();
         !openapi_attrs.skip
     });

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -35,10 +35,10 @@ pub fn impl_OaSchema_schema(fields: &[Field], docstring: Option<String>) -> Toke
         })
         .unwrap_or_default();
     let properties = fields
-        .into_iter()
+        .iter()
         .map(|f| {
             let mut attr = FieldAttributes::try_from(&f.original.attrs).unwrap();
-            attr.merge_serde(&f);
+            attr.merge_serde(f);
             if attr.skip {
                 return quote! {};
             }
@@ -132,7 +132,7 @@ pub fn derive_oaschema_enum(
     let mut str_variants = vec![];
     for v in variants {
         let name = v.attrs.name().deserialize_name();
-        if v.fields.len() == 0 {
+        if v.fields.is_empty() {
             str_variants.push(quote! { #name.to_string(), });
         } else {
             let schema = impl_OaSchema_schema(&v.fields, None);
@@ -190,7 +190,7 @@ pub fn derive_oaschema_enum(
         }
     }
 
-    if str_variants.len() > 0 {
+    if !str_variants.is_empty() {
         match tag {
             TagType::External => complex_variants
                 .push(quote! { ::oasgen::Schema::new_str_enum(vec![#(#str_variants)*]) }),

--- a/oasgen/examples/actix.rs
+++ b/oasgen/examples/actix.rs
@@ -2,9 +2,12 @@
 // forwarding to an inner mod fixes the issue.
 #[cfg(feature = "actix")]
 #[cfg(feature = "swagger-ui")]
-mod inner {
-    use actix_web::web::Json;
-    use oasgen::{oasgen, OaSchema, Server};
+pub mod inner {
+    use actix_web::{guard, web::Json};
+    use oasgen::{
+        actix::{post, scope},
+        oasgen, OaSchema, Server,
+    };
     use serde::{Deserialize, Serialize};
 
     #[derive(OaSchema, Deserialize)]
@@ -35,29 +38,40 @@ mod inner {
         Json(())
     }
 
+    #[oasgen]
+    async fn pong() -> Json<String> {
+        Json("pong".into())
+    }
+
     #[tokio::main]
     pub async fn main() -> std::io::Result<()> {
         use actix_web::{web, App, HttpResponse, HttpServer};
 
         let host = ("0.0.0.0", 5000);
 
-        let server = Server::actix()
-            .post("/send-code", send_code)
-            .post("/verify-code", verify_code)
-            .route_json_spec("/docs/openapi.json")
-            .route_yaml_spec("/docs/openapi.yaml")
-            .swagger_ui("/docs/")
-            .write_and_exit_if_env_var_set("./openapi.yaml")
-            .freeze();
-
         println!("Listening on {:?}", host);
+        println!("Swagger http://{}:{}/docs/", host.0, host.1);
+
         HttpServer::new(move || {
+            let server = Server::actix()
+                .service(
+                    scope("/code")
+                        .route("/send-code", post().to(send_code))
+                        .route("/verify-code", post().guard(guard::Post()).to(verify_code)),
+                )
+                .get("/ping", pong)
+                .route_json_spec("/docs/openapi.json")
+                .route_yaml_spec("/docs/openapi.yaml")
+                .swagger_ui("/docs/")
+                .write_and_exit_if_env_var_set("./openapi.yaml")
+                .freeze();
+
             App::new()
                 .route(
                     "/healthcheck",
                     web::get().to(|| async { HttpResponse::Ok().body("Ok") }),
                 )
-                .service(server.clone().into_service())
+                .service(server.into_service())
         })
         .bind(host)?
         .run()

--- a/oasgen/examples/actix.rs
+++ b/oasgen/examples/actix.rs
@@ -39,8 +39,8 @@ pub mod inner {
     }
 
     #[oasgen]
-    async fn pong() -> Json<String> {
-        Json("pong".into())
+    async fn pong() -> &'static str {
+        "pong"
     }
 
     #[tokio::main]

--- a/oasgen/src/lib.rs
+++ b/oasgen/src/lib.rs
@@ -1,13 +1,16 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-
 #![allow(unused)]
-mod server;
+
 mod format;
+mod server;
 
 pub use format::*;
-pub use oasgen_macro::{OaSchema, oasgen};
-pub use server::Server;
 pub use oasgen_core::*;
+pub use oasgen_macro::{oasgen, OaSchema};
+pub use server::Server;
+
+#[cfg(feature = "actix")]
+pub use server::actix;
 
 #[cfg(feature = "swagger-ui")]
 #[cfg_attr(docsrs, doc(cfg(feature = "swagger-ui")))]
@@ -15,7 +18,7 @@ pub use swagger_ui;
 
 pub mod __private {
     pub use inventory;
-    pub use oasgen_core::{SchemaRegister, OperationRegister};
+    pub use oasgen_core::{OperationRegister, SchemaRegister};
 
     pub fn fn_path_to_op_id(type_name: &str) -> Option<String> {
         Some(type_name.split("::").skip(1).collect::<Vec<_>>().join("_"))
@@ -49,7 +52,9 @@ pub fn generate_openapi() -> OpenAPI {
     let mut openapi = OpenAPI::default();
     for flag in inventory::iter::<oasgen_core::SchemaRegister> {
         let schema = (flag.constructor)();
-        openapi.schemas.insert(flag.name.to_string(), ReferenceOr::Item(schema));
+        openapi
+            .schemas
+            .insert(flag.name.to_string(), ReferenceOr::Item(schema));
     }
     // This is required to have stable diffing between builds
     openapi.schemas.sort_keys();

--- a/oasgen/src/server.rs
+++ b/oasgen/src/server.rs
@@ -227,6 +227,11 @@ pub(crate) fn add_handler_to_spec<F>(
         .as_mut()
         .expect("Currently don't support references for PathItem");
     let type_name = std::any::type_name::<F>();
+
+    // Handlers are stored in `OPERATION_LOOKUP` without generics,
+    // so strip `type_name` of generic part.
+    let type_name = type_name.split('<').next().unwrap_or(type_name);
+
     let mut operation = OPERATION_LOOKUP
         .get(type_name)
         .unwrap_or_else(|| panic!("Operation {type_name} not found in OpenAPI spec."))(

--- a/oasgen/src/server.rs
+++ b/oasgen/src/server.rs
@@ -5,20 +5,23 @@ use std::path::Path;
 use std::sync::Arc;
 
 use http::Method;
+use indexmap::IndexMap;
 use once_cell::sync::Lazy;
-use openapiv3::{OpenAPI, Operation, ReferenceOr, Parameter, ParameterKind};
+use openapiv3::{OpenAPI, Operation, Parameter, ParameterKind, PathItem, RefOr, ReferenceOr};
 
-use oasgen_core::{OaSchema};
+use oasgen_core::OaSchema;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "actix")))]
 #[cfg(feature = "actix")]
-mod actix;
+pub mod actix;
 #[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 #[cfg(feature = "axum")]
 mod axum;
 mod none;
 
-static OPERATION_LOOKUP: Lazy<HashMap<&'static str, &'static (dyn Fn() -> Operation + Send + Sync)>> = Lazy::new(|| {
+static OPERATION_LOOKUP: Lazy<
+    HashMap<&'static str, &'static (dyn Fn() -> Operation + Send + Sync)>,
+> = Lazy::new(|| {
     let mut map = HashMap::new();
     for flag in inventory::iter::<oasgen_core::OperationRegister> {
         let z: &'static (dyn Fn() -> Operation + Send + Sync) = flag.constructor;
@@ -66,12 +69,18 @@ impl<Router: Clone> Clone for Server<Router, Arc<OpenAPI>> {
     }
 }
 
+pub trait HandlerSpec {
+    fn paths(&mut self) -> impl Iterator<Item = (String, RefOr<PathItem>)>;
+}
+
 impl<Router: Default> Server<Router, OpenAPI> {
     pub fn new() -> Self {
         let mut openapi = OpenAPI::default();
         for flag in inventory::iter::<oasgen_core::SchemaRegister> {
             let schema = (flag.constructor)();
-            openapi.schemas.insert(flag.name.to_string(), ReferenceOr::Item(schema));
+            openapi
+                .schemas
+                .insert(flag.name.to_string(), ReferenceOr::Item(schema));
         }
         // This is required to have stable diffing between builds
         openapi.schemas.sort_keys();
@@ -90,25 +99,12 @@ impl<Router: Default> Server<Router, OpenAPI> {
 
     /// Add a handler to the OpenAPI spec (which is different than mounting it to a server).
     fn add_handler_to_spec<F>(&mut self, path: &str, method: Method, _handler: &F) {
-        use http::Method;
-        let item = self.openapi.paths.paths.entry(path.to_string()).or_default();
-        let item = item.as_mut().expect("Currently don't support references for PathItem");
-        let type_name = std::any::type_name::<F>();
-        let mut operation = OPERATION_LOOKUP.get(type_name)
+        add_handler_to_spec::<F>(&mut self.openapi.paths.paths, path, method)
+    }
 
-            .expect(&format!("Operation {} not found in OpenAPI spec.", type_name))();
-        modify_parameter_names(&mut operation, &path);
-        match method {
-            Method::GET => item.get = Some(operation),
-            Method::POST => item.post = Some(operation),
-            Method::PUT => item.put = Some(operation),
-            Method::DELETE => item.delete = Some(operation),
-            Method::OPTIONS => item.options = Some(operation),
-            Method::HEAD => item.head = Some(operation),
-            Method::PATCH => item.patch = Some(operation),
-            Method::TRACE => item.trace = Some(operation),
-            _ => panic!("Unsupported method: {}", method),
-        }
+    /// Extends the OpenAPI spec with the provided handlers (which is different than mounting it to a server).
+    fn extend_handler_spec(&mut self, handler: &mut impl HandlerSpec) {
+        self.openapi.paths.paths.extend(handler.paths());
     }
 
     /// Configure the server to add a route that serves the spec as JSON
@@ -185,7 +181,8 @@ impl<Router: Default> Server<Router, OpenAPI> {
         let path = path.as_ref();
         if var("OASGEN_WRITE_SPEC").map(|s| s == "1").unwrap_or(false) {
             let spec = if path.extension().map(|e| e == "json").unwrap_or(false) {
-                serde_json::to_string(&self.openapi).expect("Serializing OpenAPI spec to JSON failed.")
+                serde_json::to_string(&self.openapi)
+                    .expect("Serializing OpenAPI spec to JSON failed.")
             } else {
                 serde_yaml::to_string(&self.openapi).expect("Serializing OpenAPI spec failed.")
             };
@@ -214,15 +211,52 @@ impl<Router: Default> Server<Router, OpenAPI> {
     }
 }
 
+impl<Router: Default> Default for Server<Router, OpenAPI> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub(crate) fn add_handler_to_spec<F>(
+    paths: &mut IndexMap<String, RefOr<PathItem>>,
+    path: &str,
+    method: Method,
+) {
+    let item = paths.entry(path.to_string()).or_default();
+    let item = item
+        .as_mut()
+        .expect("Currently don't support references for PathItem");
+    let type_name = std::any::type_name::<F>();
+    let mut operation = OPERATION_LOOKUP
+        .get(type_name)
+        .unwrap_or_else(|| panic!("Operation {type_name} not found in OpenAPI spec."))(
+    );
+    modify_parameter_names(&mut operation, path);
+    match method {
+        Method::GET => item.get = Some(operation),
+        Method::POST => item.post = Some(operation),
+        Method::PUT => item.put = Some(operation),
+        Method::DELETE => item.delete = Some(operation),
+        Method::OPTIONS => item.options = Some(operation),
+        Method::HEAD => item.head = Some(operation),
+        Method::PATCH => item.patch = Some(operation),
+        Method::TRACE => item.trace = Some(operation),
+        _ => panic!("Unsupported method: {}", method),
+    }
+}
+
 // Note: this takes an OpenAPI url, which parameterizes like: /path/{param}
 fn modify_parameter_names(operation: &mut Operation, path: &str) {
     if !path.contains("{") {
         return;
     }
-    let path_parts = path.split("/")
+    let path_parts = path
+        .split("/")
         .filter(|part| part.starts_with("{"))
         .map(|part| &part[1..part.len() - 1]);
-    let path_params = operation.parameters.iter_mut()
+    let path_params = operation
+        .parameters
+        .iter_mut()
         .filter_map(|mut p| p.as_mut())
         .filter(|p| matches!(p.kind, ParameterKind::Path { .. }));
 
@@ -240,10 +274,22 @@ mod tests {
     fn test_modify_parameter_names() {
         let path = "/api/v1/pet/{id}/";
         let mut operation = Operation::default();
-        operation.parameters.push(Parameter::path("path", oa::Schema::new_number()).into());
-        operation.parameters.push(Parameter::query("query", oa::Schema::new_number()).into());
+        operation
+            .parameters
+            .push(Parameter::path("path", oa::Schema::new_number()).into());
+        operation
+            .parameters
+            .push(Parameter::query("query", oa::Schema::new_number()).into());
         modify_parameter_names(&mut operation, path);
-        assert_eq!(operation.parameters[0].as_item().unwrap().name, "id", "path param name is updated");
-        assert_eq!(operation.parameters[1].as_item().unwrap().name, "query", "leave query param alone");
+        assert_eq!(
+            operation.parameters[0].as_item().unwrap().name,
+            "id",
+            "path param name is updated"
+        );
+        assert_eq!(
+            operation.parameters[1].as_item().unwrap().name,
+            "query",
+            "leave query param alone"
+        );
     }
 }

--- a/oasgen/src/server/axum.rs
+++ b/oasgen/src/server/axum.rs
@@ -110,7 +110,7 @@ impl<S> Server<Router<S>, Arc<OpenAPI>>
         if let Some(json_route) = &self.json_route {
             let spec = self.openapi.as_ref();
             let bytes = serde_json::to_vec(spec).unwrap();
-            router = router.route(&json_route, routing::get(|| async {
+            router = router.route(json_route, routing::get(|| async {
                 (
                     [(
                         http::header::CONTENT_TYPE,
@@ -124,7 +124,7 @@ impl<S> Server<Router<S>, Arc<OpenAPI>>
         if let Some(yaml_route) = &self.yaml_route {
             let spec = self.openapi.as_ref();
             let yaml = serde_yaml::to_string(spec).unwrap();
-            router = router.route(&yaml_route, routing::get(|| async {
+            router = router.route(yaml_route, routing::get(|| async {
                 (
                     [(
                         http::header::CONTENT_TYPE,
@@ -154,7 +154,7 @@ impl<S> Server<Router<S>, Arc<OpenAPI>>
                 }
             });
             router = router
-                .route(&format!("{}", &path), handler.clone());
+                .route(&path.to_string(), handler.clone());
             router = router
                 .route(&format!("{}{{*rest}}", &path), handler)
         }

--- a/oasgen/tests/test-actix/01-hello.yaml
+++ b/oasgen/tests/test-actix/01-hello.yaml
@@ -14,7 +14,7 @@ paths:
         required: true
       responses:
         '200':
-          description: ''
+          description: OK
           content:
             application/json:
               schema:
@@ -30,7 +30,7 @@ paths:
         style: form
       responses:
         '200':
-          description: ''
+          description: OK
           content:
             application/json:
               schema:

--- a/oasgen/tests/test-axum/01-hello.yaml
+++ b/oasgen/tests/test-axum/01-hello.yaml
@@ -18,7 +18,7 @@ paths:
         required: true
       responses:
         '200':
-          description: ''
+          description: OK
           content:
             application/json:
               schema:


### PR DESCRIPTION
Added/refactored some Actix functionality to support more use cases.
Let me know if you have any comments.

# Features
* Add support for guards & scopes to the Actix server implementation.
* Add `skip(..)/skip_all/rename` attributes to `oasgen` macro.
* Impl `OaScheme` for `&str`.
* Impl `OaScheme` for `[T; N]`.

# Refactor
* `OaParameter` impl for Actix `Path` to support structs.
* `OaParameter` impl for  `QsQuery` to be the same as Actix `Query`.