### PR TITLE
Make `Option<Struct>` nullable in schema

### DIFF
--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use openapiv3::{RefOr, ReferenceOr, Schema, SchemaData, SchemaKind};
+use openapiv3::{ReferenceOr, Schema};
 
 #[cfg(feature = "actix")]
 mod actix;
@@ -124,21 +124,11 @@ where
 
     fn schema_ref() -> ReferenceOr<Schema> {
         let mut schema = T::schema_ref();
-        match schema.as_mut() {
-            Some(s) => {
-                s.nullable = true;
-                schema
-            }
-            None => RefOr::Item(Schema {
-                data: SchemaData {
-                    nullable: true,
-                    ..Default::default()
-                },
-                kind: SchemaKind::AllOf {
-                    all_of: vec![schema],
-                },
-            }),
-        }
+        let Some(s) = schema.as_mut() else {
+            return schema;
+        };
+        s.nullable = true;
+        schema
     }
 }
 

--- a/oasgen/tests/test-none/02-required.yaml
+++ b/oasgen/tests/test-none/02-required.yaml
@@ -10,4 +10,3 @@ properties:
     type: string
 required:
 - is_required
-- is_nullable

--- a/oasgen/tests/test-none/03-newtype.rs
+++ b/oasgen/tests/test-none/03-newtype.rs
@@ -21,6 +21,7 @@ pub struct Foo {
     prop_b: StructNewType,
     #[oasgen(skip)]
     prop_c: StructNewType,
+    prop_d: Option<Struct>,
 }
 
 fn main() {

--- a/oasgen/tests/test-none/03-newtype.yaml
+++ b/oasgen/tests/test-none/03-newtype.yaml
@@ -17,11 +17,8 @@ properties:
     required:
     - test
   prop_d:
-    nullable: true
-    allOf:
-    - $ref: '#/components/schemas/Struct'
+    $ref: '#/components/schemas/Struct'
 required:
 - id
 - prop_a
 - prop_b
-- prop_d

--- a/oasgen/tests/test-none/03-newtype.yaml
+++ b/oasgen/tests/test-none/03-newtype.yaml
@@ -16,7 +16,12 @@ properties:
         type: integer
     required:
     - test
+  prop_d:
+    nullable: true
+    allOf:
+    - $ref: '#/components/schemas/Struct'
 required:
 - id
 - prop_a
 - prop_b
+- prop_d


### PR DESCRIPTION
Currently `Option<Struct>` is just encoded as a `#ref` to the struct (without being nullable).

This PR makes `Option<Struct>` encode as a nullable `allOf` with the only entry being the `#ref` to the struct.