### PR TITLE
Fix handling of `operation_id` in `oasgen` macro

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -95,7 +95,7 @@ pub fn oasgen(attr: TokenStream, input: TokenStream) -> TokenStream {
     let operation_id = if let Some(id) = attr.operation_id {
         let id = id.value();
         quote! {
-            op.operation_id = Some(#id.to_string())
+            Some(#id.to_string())
         }
     } else {
         quote! {


### PR DESCRIPTION
This fixes the handling of the `operation_id` field in the `oasgen` attribute in the scenario when the field is set. Since the value of the `operation_id` is attached to the `Operation` within the macro, like the `deprecated` field, it should be not include the `op.operation = ` prefix in its value.