### PR TITLE
Add required field to parameters in path

### DIFF
--- a/oasgen/src/server.rs
+++ b/oasgen/src/server.rs
@@ -228,6 +228,7 @@ fn modify_parameter_names(operation: &mut Operation, path: &str) {
 
     for (part, param) in path_parts.zip(path_params) {
         param.name = part.to_string();
+        param.required = true;
     }
 }
 

--- a/oasgen/tests/test-actix/01-hello.yaml
+++ b/oasgen/tests/test-actix/01-hello.yaml
@@ -14,7 +14,7 @@ paths:
         required: true
       responses:
         '200':
-          description: ''
+          description: OK
           content:
             application/json:
               schema:
@@ -30,7 +30,7 @@ paths:
         style: form
       responses:
         '200':
-          description: ''
+          description: OK
           content:
             application/json:
               schema:

--- a/oasgen/tests/test-axum/01-hello.yaml
+++ b/oasgen/tests/test-axum/01-hello.yaml
@@ -18,7 +18,7 @@ paths:
         required: true
       responses:
         '200':
-          description: ''
+          description: OK
           content:
             application/json:
               schema:

--- a/oasgen/tests/test-axum/03-path.yaml
+++ b/oasgen/tests/test-axum/03-path.yaml
@@ -8,6 +8,7 @@ paths:
       operationId: get_task
       parameters:
       - name: id
+        required: true
         schema:
           type: integer
         in: path
@@ -18,11 +19,13 @@ paths:
       operationId: get_stuff
       parameters:
       - name: id
+        required: true
         schema:
           type: integer
         in: path
         style: simple
       - name: tu
+        required: true
         schema:
           type: integer
         in: path


### PR DESCRIPTION
This adds the `required` field (set to `true`) for parameters that are in the path. The intent is to resolve the validation errors found in schema validators such as [editor.swagger.io](https://editor.swagger.io/).

Example from editor.swagger.io:
<img width="471" height="144" alt="Screenshot 2025-08-25 at 4 23 48 PM" src="https://github.com/user-attachments/assets/951deebe-6b8a-44ea-b6a5-29bee35c5a9f" />


