### PR TITLE
Add field-level descriptions

### DIFF
--- a/macro/src/attr.rs
+++ b/macro/src/attr.rs
@@ -9,6 +9,7 @@ use syn::LitStr;
 /// For example, `skip` will be applied with either `#[oasgen(skip)]` or `#[serde(skip)]`.
 #[derive(StructMeta, Default)]
 pub struct FieldAttributes {
+    pub description: Option<LitStr>,
     pub skip: bool,
     pub skip_serializing_if: Option<LitStr>,
     /// By default, oasgen will use references when possible
@@ -46,6 +47,7 @@ impl TryFrom<&Vec<syn::Attribute>> for FieldAttributes {
     type Error = syn::Error;
 
     fn try_from(attrs: &Vec<syn::Attribute>) -> Result<Self, Self::Error> {
+        let docstring = get_docstring(attrs.as_slice()).expect("Failed to parse docstring");
         let attrs = attrs
             .into_iter()
             .filter(|a| a.path().get_ident().map(|i| i == "oasgen").unwrap_or(false))
@@ -56,6 +58,10 @@ impl TryFrom<&Vec<syn::Attribute>> for FieldAttributes {
         for attr in attrs {
             result.merge_with(&attr);
         }
+        if let Some(docstring) = docstring {
+            result.description = Some(LitStr::new(&docstring, proc_macro2::Span::call_site()));
+        }
+
         Ok(result)
     }
 }

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -44,6 +44,7 @@ pub fn impl_OaSchema_schema(fields: &[Field], docstring: Option<String>) -> Toke
             }
 
             let name = f.attrs.name().deserialize_name();
+            let description = attr.description;
             let ty = f.ty;
             let schema = quote! {
                 <#ty as ::oasgen::OaSchema>::schema()
@@ -65,12 +66,32 @@ pub fn impl_OaSchema_schema(fields: &[Field], docstring: Option<String>) -> Toke
                     quote! { o.required_mut().push(#name.to_string()); }
                 }).unwrap_or_default();
                 let schema_ref = if attr.inline {
-                    quote! {
-                        <#ty as ::oasgen::OaSchema>::schema()
+                    if let Some(description) = &description {
+                        quote! {
+                            {
+                                let mut s = <#ty as ::oasgen::OaSchema>::schema();
+                                s.description = Some(#description.into());
+                                s
+                            }
+                        }
+                    } else {
+                        quote! {
+                            <#ty as ::oasgen::OaSchema>::schema()
+                        }
                     }
                 } else {
-                    quote! {
-                        <#ty as ::oasgen::OaSchema>::schema_ref()
+                    if let Some(description) = &description {
+                        quote! {
+                            {
+                                let mut s = <#ty as ::oasgen::OaSchema>::schema_ref().into_item().expect("Reference must resolve to item");
+                                s.description = Some(#description.into());
+                                ::oasgen::ReferenceOr::Item(s)
+                            }
+                        }
+                    } else {
+                        quote! {
+                            <#ty as ::oasgen::OaSchema>::schema_ref()
+                        }
                     }
                 };
                 quote! {

--- a/macro/src/util.rs
+++ b/macro/src/util.rs
@@ -83,9 +83,15 @@ pub fn impl_OaSchema_schema(fields: &[Field], docstring: Option<String>) -> Toke
                     if let Some(description) = &description {
                         quote! {
                             {
-                                let mut s = <#ty as ::oasgen::OaSchema>::schema_ref().into_item().expect("Reference must resolve to item");
-                                s.description = Some(#description.into());
-                                ::oasgen::ReferenceOr::Item(s)
+                                let schema_ref = <#ty as ::oasgen::OaSchema>::schema_ref();
+                                let schema_item = match schema_ref.clone().into_item() {
+                                    Some(mut s) => {
+                                        s.description = Some(#description.into());
+                                        ::oasgen::ReferenceOr::Item(s)
+                                    }
+                                    None => schema_ref,
+                                };
+                                schema_item
                             }
                         }
                     } else {

--- a/oasgen/tests/test-actix/01-hello.rs
+++ b/oasgen/tests/test-actix/01-hello.rs
@@ -2,13 +2,16 @@ use actix_web::web::{Json, Query, Data};
 use oasgen::{oasgen, OaSchema, Server};
 use serde::{Deserialize, Serialize};
 
+/// Send a code to a mobile number
 #[derive(Deserialize, OaSchema)]
 pub struct SendCode {
+    /// Mobile phone number
     pub mobile: String,
 }
 
 #[derive(Serialize, OaSchema)]
 pub struct SendCodeResponse {
+    /// Indicates account found
     pub found_account: bool,
 }
 

--- a/oasgen/tests/test-actix/01-hello.yaml
+++ b/oasgen/tests/test-actix/01-hello.yaml
@@ -14,7 +14,7 @@ paths:
         required: true
       responses:
         '200':
-          description: ''
+          description: OK
           content:
             application/json:
               schema:
@@ -30,7 +30,7 @@ paths:
         style: form
       responses:
         '200':
-          description: ''
+          description: OK
           content:
             application/json:
               schema:
@@ -52,9 +52,11 @@ components:
       required:
       - code
     SendCode:
+      description: Send a code to a mobile number
       type: object
       properties:
         mobile:
+          description: Mobile phone number
           type: string
       required:
       - mobile
@@ -62,6 +64,7 @@ components:
       type: object
       properties:
         found_account:
+          description: Indicates account found
           type: boolean
       required:
       - found_account

--- a/oasgen/tests/test-axum/01-hello.rs
+++ b/oasgen/tests/test-axum/01-hello.rs
@@ -5,11 +5,13 @@ use serde::{Deserialize, Serialize};
 /// Send a code to a mobile number
 #[derive(Deserialize, OaSchema)]
 pub struct SendCode {
+    /// Mobile phone number
     pub mobile: String,
 }
 
 #[derive(Serialize, OaSchema)]
 pub struct SendCodeResponse {
+    /// Indicates account found
     pub found_account: bool,
 }
 

--- a/oasgen/tests/test-axum/01-hello.yaml
+++ b/oasgen/tests/test-axum/01-hello.yaml
@@ -18,7 +18,7 @@ paths:
         required: true
       responses:
         '200':
-          description: ''
+          description: OK
           content:
             application/json:
               schema:
@@ -30,6 +30,7 @@ components:
       description: Send a code to a mobile number
       properties:
         mobile:
+          description: Mobile phone number
           type: string
       required:
       - mobile
@@ -37,6 +38,7 @@ components:
       type: object
       properties:
         found_account:
+          description: Indicates account found
           type: boolean
       required:
       - found_account


### PR DESCRIPTION
This adds support to capture docstrings on struct fields as descriptions in the generated object properties. 